### PR TITLE
CLOUD-20 Update CI pipeline to check for gofmt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,29 @@ jobs:
           root: .
           paths: .
 
-  # Run the golang linters using golangci-lint. The linters that will be run are
-  # defined inside the .golangci.yml file.
-  lint:
+  # Make sure that `gofmt` was run.
+  gofmt:
     executor: go-exec
     steps:
       # A special step used to attach the workflow's workspace to the current
       # executor. The full contents of the workspace are downloaded and copied
       # into the directory the workspace is being attached at.
+      - attach_workspace:
+          at: .
+      # Copy the contents of the project into a separate folder, run gofmt, and
+      # check the diff. Note that we are creating a copy of the original
+      # project, because we don't know which is the project folder. If the
+      # project lives inside /tmp then diff will never return true.
+      - run: cp -r ./ /tmp/service_orig
+      - run: cp -r /tmp/service_orig /tmp/service_fmt
+      - run: cd /tmp/service_fmt && go fmt ./...        # gofmt must be run from within the folder
+      - run: diff -r /tmp/service_orig /tmp/service_fmt # exits with error if there is a diff
+
+  # Run the linters.
+  lint:
+    executor: go-exec
+    steps:
+      # Attach the workspace to the current executor.
       - attach_workspace:
           at: .
       # Install golangci-lint, see: https://golangci-lint.run/usage/install/.
@@ -37,7 +52,8 @@ jobs:
             GOLANGCI_LINT_VERSION: v1.55.2
           command: |
             wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_LINT_VERSION}
-      # Run the linters.
+      # Run the golang linters using golangci-lint. The linters that will be run
+      # are defined inside the .golangci.yml file.
       - run: golangci-lint run -v ./...
 
   # Run the unit tests.
@@ -119,7 +135,10 @@ workflows:
       # Pull the src code.
       - pull
 
-      # Linting and testing should run after the code was pulled.
+      # Fmt, lint and tests should run after the code was pulled.
+      - gofmt:
+          requires:
+            - pull
       - lint:
           requires:
             - pull

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,69 @@
+# This Dockerfile uses a multi-stage build.
+# https://docs.docker.com/build/building/multi-stage/
+#
+# In order to keep the production image as small as possible we
+# will have two separate stages: one for building the binary, and
+# another for running that binary.
+# The first stage uses a full-scale Go image to build the binary.
+# The second stage uses the scratch image as its base and copies
+# just the built binary from the previous stage. None of the
+# build tools required to build the application are included in
+# the resulting image.
+
+
+#---------------------------------------------------------------#
 # Build
-FROM golang:1.21.2-alpine as builder
+#
+# For compiling the service binary we will use the latest golang
+# image. Name the build stage so that we can refer to it from
+# later stages.
+FROM golang:1.21.2-alpine AS builder
 
-ENV GO111MODULE=on
-ENV GOPRIVATE=github.com/eventscompass
-ENV GOOS=linux
+# Set the working directory inside the docker container.
+# Note that if we are not careful we might accidentally overwrite
+# some files or folders of the default folder. The `/usr` folder
+# is considered a safe place to put the service files.
+# The folder `/usr/service` will be created if it does not exists.
+WORKDIR /usr/service
 
-WORKDIR /service
-COPY . .
+# Install all the dependencies inside the docker image workdir.
+# Note that the dependencies are committed to the repo, so we can
+# simply copy them instead of downloading with `go mod download`.
+COPY go.mod go.sum ./
+COPY ./vendor ./vendor/
 
-RUN CGO_ENABLED=0 go build -o "/tmp/eventsservice" ./src
+# Copy the src code.
+# We could also do simply `COPY ./ ./`, but splitting the copy
+# operation into two different steps improves cache reuse.
+# Changing the src files during development and re-building the
+# image will not invalidate the entire copy step.
+COPY ./src ./src/
 
-#####
+# Compile the service binary.
+RUN \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    go build -o "./eventsservice" ./src
 
+
+#---------------------------------------------------------------#
 # Run
+#
+# Run the service binary with the scratch image as base.
 FROM scratch
-COPY --from=builder /tmp/eventsservice .
-EXPOSE 8080
+
+# Copy just the built artifact from the previous stage into this
+# new stage. Any intermediate artifacts are left behind.
+COPY --from=builder /usr/service/eventsservice ./
+
+# The `EXPOSE` function does not publish the port.
+# But we can document in the Dockerfile what ports the
+# application is going to listen on by default.
+# https://docs.docker.com/engine/reference/builder/#expose
+#
+# The REST server listens on port 8080, and the gRPC - on 8081.
+EXPOSE 8080/tcp
+EXPOSE 8081/tcp
+
+# Run the service binary.
 CMD [ "./eventsservice" ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The `Events` micro-service manages the events on the platform.
 It can be used to create new events or to retrieve existing events.
 Events can be retrieved using their unique ID, or by their name.
 
+
 ## REST API
 | method | route                           | description                   |
 |--------|---------------------------------|-------------------------------|
@@ -13,3 +14,24 @@ Events can be retrieved using their unique ID, or by their name.
 |  GET   | `/api/events/name/<event_name>` | retrieve an event by its name |
 |  GET   | `/api/events`                   | retrieve all events           |
 |  POST  | `/api/events`                   | create a new event            |
+
+
+## Configuration
+The service is configured using environment variables.
+
+| name                            | default  | description                                                     |
+|---------------------------------|----------|-----------------------------------------------------------------|
+| HTTP_SERVER_LISTEN              | :8080    | The address for the service to listen on for http requests.     |
+| HTTP_SERVER_READ_HEADER_TIMEOUT | 10s      | How long to wait for reading the http request headers.          |
+| HTTP_SERVER_READ_TIMEOUT        | 10s      | How long to wait for reading the http requests, including body. |
+| HTTP_SERVER_WRITE_TIMEOUT       | 30s      | How long to wait to process requests and generate a response.   |
+| HTTP_SERVER_DUMP_REQUESTS       |          |                                                                 |
+| MESSAGE_BUS_HOST                |          | The host url for connecting to a message bus.                   |
+| MESSAGE_BUS_PORT                |          | The port on which the message bus listens.                      |
+| MESSAGE_BUS_USERNAME            |          | The username for connecting to the message bus.                 |
+| MESSAGE_BUS_PASSWORD            |          | The password for connecting to the message bus.                 |
+| EVENTS_MONGO_HOST               |          | The host url for connecting to a MongoDB server.                |
+| EVENTS_MONGO_PORT               |          | The port on which the database server listens.                  |
+| EVENTS_MONGO_USERNAME           |          | The username for connecting to the server.                      |
+| EVENTS_MONGO_PASSWORD           |          | The password for connecting to the server.                      |
+| EVENTS_MONGO_DATABASE           |          | The name of the database that is allocated for this service.    |


### PR DESCRIPTION
In order to conform to the style guide rules defined in the Service-Template repository, introduce a new step in the dev-pipeline that makes sure that `gofmt` was run.