### PR TITLE
CLOUD-20 CI pipeline check for go mod tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           root: .
           paths: .
 
-  # Make sure that `gofmt` was run.
+  # Make sure that `go fmt` `go mod tidy` and `go mod vendor` were run.
   gofmt:
     executor: go-exec
     steps:
@@ -30,14 +30,17 @@ jobs:
       # into the directory the workspace is being attached at.
       - attach_workspace:
           at: .
-      # Copy the contents of the project into a separate folder, run gofmt, and
-      # check the diff. Note that we are creating a copy of the original
-      # project, because we don't know which is the project folder. If the
-      # project lives inside /tmp then diff will never return true.
-      - run: cp -r ./ /tmp/service_orig
-      - run: cp -r /tmp/service_orig /tmp/service_fmt
-      - run: cd /tmp/service_fmt && go fmt ./...        # gofmt must be run from within the folder
-      - run: diff -r /tmp/service_orig /tmp/service_fmt # exits with error if there is a diff
+      # Run `go fmt`, `go mod tidy`, and `go mod vendor`. Note that they need to
+      # be run from within the project folder. Then check the diff and fail the
+      # step if there is any. Note that `git diff` only prints the diff and does
+      # not error. Running `git diff --quiet` will error in case of diff.
+      - run: go fmt ./...
+      - run: go mod tidy
+      - run: go mod vendor
+      - run:
+          command: |
+            git --no-pager diff
+            git --no-pager diff --quiet
 
   # Run the linters.
   lint:

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eventscompass/service-framework v0.0.0-20231204141931-617d001a5e94 h1:gEzSM8PaWhMm/YkbyNXGrESP1KhALarzpnRxpImzMnc=
-github.com/eventscompass/service-framework v0.0.0-20231204141931-617d001a5e94/go.mod h1:4IfkPioDxXVVojEkSoIizzv5B3y+dv8HtIqel3yh9Ho=
-github.com/eventscompass/service-framework v1.0.0 h1:LVwWc6aXS0ja3CJItSj2OBlgtDoge3Ht5rR+1b4v2rQ=
-github.com/eventscompass/service-framework v1.0.0/go.mod h1:4IfkPioDxXVVojEkSoIizzv5B3y+dv8HtIqel3yh9Ho=
 github.com/eventscompass/service-framework v1.1.0 h1:QzUQ7u9FZaMbIrYqdf49gUoB2C1zb6wXscXvNNUg5Fo=
 github.com/eventscompass/service-framework v1.1.0/go.mod h1:4IfkPioDxXVVojEkSoIizzv5B3y+dv8HtIqel3yh9Ho=
 github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=


### PR DESCRIPTION
Update the CI pipeline to make sure that `go mod tidy` and `go mod vendor` were run before pushing.